### PR TITLE
add solana buy asset

### DIFF
--- a/buyassets/moonpay.json
+++ b/buyassets/moonpay.json
@@ -340,7 +340,7 @@
             "currency_code": "SOL",
             "asset_id": "SOL",
             "ios_blockchain": "SOL",
-            "ios_asset_protocol": "native",
+            "ios_asset_protocol": "SOL",
             "android_blockchain": "SOL_BLOCKCHAIN",
             "android_asset_protocol": "SOL_PROTOCOL"
         }

--- a/buyassets/moonpay.json
+++ b/buyassets/moonpay.json
@@ -71,7 +71,7 @@
             "ios_asset_protocol": "ERC20",
             "android_blockchain": "ETH_BLOCKCHAIN",
             "android_asset_protocol": "ERC_20_PROTOCOL"
-        },       
+        },
         {
             "currency_code": "COMP",
             "asset_id": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
@@ -335,6 +335,14 @@
             "ios_asset_protocol": "CCD",
             "android_blockchain": "CCD_BLOCKCHAIN",
             "android_asset_protocol": "CCD_PROTOCOL"
+        },
+        {
+            "currency_code": "SOL",
+            "asset_id": "SOL",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "native",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SOL_PROTOCOL"
         }
     ]
 }

--- a/buyassets/onramper.json
+++ b/buyassets/onramper.json
@@ -340,7 +340,7 @@
             "compound_key": "sol",
             "asset_id": "SOL",
             "ios_blockchain": "SOL",
-            "ios_asset_protocol": "native",
+            "ios_asset_protocol": "SOL",
             "android_blockchain": "SOL_BLOCKCHAIN",
             "android_asset_protocol": "SOL_PROTOCOL"
         }

--- a/buyassets/onramper.json
+++ b/buyassets/onramper.json
@@ -335,6 +335,14 @@
             "ios_asset_protocol": "CCD",
             "android_blockchain": "CCD_BLOCKCHAIN",
             "android_asset_protocol": "CCD_PROTOCOL"
+        },
+        {
+            "compound_key": "sol",
+            "asset_id": "SOL",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "native",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SOL_PROTOCOL"
         }
     ]
 }


### PR DESCRIPTION
This pull request adds support for the Solana (SOL) asset to both the Moonpay and Onramper buy asset configuration files. This enables users to buy and interact with SOL through these providers in the app.

**Provider configuration updates:**

* Added Solana (SOL) asset entry to `buyassets/moonpay.json`, specifying the appropriate blockchain and protocol identifiers for both iOS and Android platforms.
* Added Solana (SOL) asset entry to `buyassets/onramper.json`, including a `compound_key` and the necessary blockchain and protocol identifiers for iOS and Android.