### PR TITLE
Add Base chain buy assets (ETH, USDC)

### DIFF
--- a/Tests/AssetConvertersTests/AssetConvertersTests.swift
+++ b/Tests/AssetConvertersTests/AssetConvertersTests.swift
@@ -25,13 +25,25 @@ final class AssetConvertersTests: XCTestCase {
         XCTAssertEqual(sut.convertProviderAssetToAssetIdV2(asset: "VERSE-ETH", provider: .simplex), nil)
     }
 
+    func testCanConvertBaseProviderAssetToAssetIdV2() {
+        XCTAssertEqual(sut.convertProviderAssetToAssetIdV2(asset: "ETH-BASE", provider: .banxa), "BASE-ETH-ETH")
+        XCTAssertEqual(sut.convertProviderAssetToAssetIdV2(asset: "USDC-BASE", provider: .banxa), "BASE-ERC20-0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")
+        XCTAssertEqual(sut.convertProviderAssetToAssetIdV2(asset: "ETH_BASE", provider: .moonpay), "BASE-ETH-ETH")
+        XCTAssertEqual(sut.convertProviderAssetToAssetIdV2(asset: "USDC_BASE", provider: .moonpay), "BASE-ERC20-0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")
+    }
+
     func testCanConvertAssetIdV2ToProviderAsset() {
         XCTAssertEqual(sut.convertAssetIdV2ToProviderAsset(assetIdV2: "ETH-ERC20-0x249cA82617eC3DfB2589c4c17ab7EC9765350a18", provider: .banxa), "VERSE-ETH")
         XCTAssertEqual(sut.convertAssetIdV2ToProviderAsset(assetIdV2: "ETH-ERC20-0x249cA82617eC3DfB2589c4c17ab7EC9765350a18", provider: .moonpay), "VERSE")
         XCTAssertEqual(sut.convertAssetIdV2ToProviderAsset(assetIdV2: "ETH-ERC20-0x249cA82617eC3DfB2589c4c17ab7EC9765350a18", provider: .simplex), nil)
-        
+
         XCTAssertEqual(sut.convertAssetIdV2ToProviderAsset(assetIdV2: "eth-erc20-0x249ca82617ec3dfb2589c4c17ab7ec9765350a18", provider: .banxa), "VERSE-ETH")
         XCTAssertEqual(sut.convertAssetIdV2ToProviderAsset(assetIdV2: "eth-erc20-0x249ca82617ec3dfb2589c4c17ab7ec9765350a18", provider: .moonpay), "VERSE")
         XCTAssertEqual(sut.convertAssetIdV2ToProviderAsset(assetIdV2: "eth-erc20-0x249ca82617ec3dfb2589c4c17ab7ec9765350a18", provider: .simplex), nil)
+    }
+
+    func testCanConvertBaseAssetIdV2ToProviderAsset() {
+        XCTAssertEqual(sut.convertAssetIdV2ToProviderAsset(assetIdV2: "BASE-ETH-ETH", provider: .banxa), "ETH-BASE")
+        XCTAssertEqual(sut.convertAssetIdV2ToProviderAsset(assetIdV2: "BASE-ETH-ETH", provider: .moonpay), "ETH_BASE")
     }
 }

--- a/buyassets/banxa.json
+++ b/buyassets/banxa.json
@@ -1,6 +1,22 @@
 {
     "assets": [
         {
+            "compound_key": "ETH-BASE",
+            "asset_id": "ETH",
+            "ios_blockchain": "BASE",
+            "ios_asset_protocol": "ETH",
+            "android_blockchain": "BASE_BLOCKCHAIN",
+            "android_asset_protocol": "ETH_PROTOCOL"
+        },
+        {
+            "compound_key": "USDC-BASE",
+            "asset_id": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "ios_blockchain": "BASE",
+            "ios_asset_protocol": "ERC20",
+            "android_blockchain": "BASE_BLOCKCHAIN",
+            "android_asset_protocol": "ERC_20_PROTOCOL"
+        },
+        {
             "compound_key": "BTC-BTC",
             "asset_id": "BTC",
             "ios_blockchain": "BTC",

--- a/buyassets/moonpay.json
+++ b/buyassets/moonpay.json
@@ -1,6 +1,22 @@
 {
     "assets": [
         {
+            "currency_code": "ETH_BASE",
+            "asset_id": "ETH",
+            "ios_blockchain": "BASE",
+            "ios_asset_protocol": "ETH",
+            "android_blockchain": "BASE_BLOCKCHAIN",
+            "android_asset_protocol": "ETH_PROTOCOL"
+        },
+        {
+            "currency_code": "USDC_BASE",
+            "asset_id": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "ios_blockchain": "BASE",
+            "ios_asset_protocol": "ERC20",
+            "android_blockchain": "BASE_BLOCKCHAIN",
+            "android_asset_protocol": "ERC_20_PROTOCOL"
+        },
+        {
             "currency_code": "AAVE",
             "asset_id": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
             "ios_blockchain": "ETH",

--- a/ios/Resources/buyassets/banxa.json
+++ b/ios/Resources/buyassets/banxa.json
@@ -1,6 +1,22 @@
 {
     "assets": [
         {
+            "compound_key": "ETH-BASE",
+            "asset_id": "ETH",
+            "ios_blockchain": "BASE",
+            "ios_asset_protocol": "ETH",
+            "android_blockchain": "BASE_BLOCKCHAIN",
+            "android_asset_protocol": "ETH_PROTOCOL"
+        },
+        {
+            "compound_key": "USDC-BASE",
+            "asset_id": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "ios_blockchain": "BASE",
+            "ios_asset_protocol": "ERC20",
+            "android_blockchain": "BASE_BLOCKCHAIN",
+            "android_asset_protocol": "ERC_20_PROTOCOL"
+        },
+        {
             "compound_key": "BTC-BTC",
             "asset_id": "BTC",
             "ios_blockchain": "BTC",

--- a/ios/Resources/buyassets/moonpay.json
+++ b/ios/Resources/buyassets/moonpay.json
@@ -1,6 +1,22 @@
 {
     "assets": [
         {
+            "currency_code": "ETH_BASE",
+            "asset_id": "ETH",
+            "ios_blockchain": "BASE",
+            "ios_asset_protocol": "ETH",
+            "android_blockchain": "BASE_BLOCKCHAIN",
+            "android_asset_protocol": "ETH_PROTOCOL"
+        },
+        {
+            "currency_code": "USDC_BASE",
+            "asset_id": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "ios_blockchain": "BASE",
+            "ios_asset_protocol": "ERC20",
+            "android_blockchain": "BASE_BLOCKCHAIN",
+            "android_asset_protocol": "ERC_20_PROTOCOL"
+        },
+        {
             "currency_code": "AAVE",
             "asset_id": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
             "ios_blockchain": "ETH",


### PR DESCRIPTION
## Summary
- Add Base chain buy-asset mappings for **Banxa** and **Moonpay** (ETH and USDC)
- Update both `buyassets/` source JSON and `ios/Resources/buyassets/` resource copies
- Add tests covering provider-asset ↔ assetIdV2 conversion for Base:
  - `ETH-BASE`/`ETH_BASE` → `BASE-ETH-ETH`
  - `USDC-BASE`/`USDC_BASE` → `BASE-ERC20-0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`

## Test plan
- [ ] `swift test` passes (new `testCanConvertBaseProviderAssetToAssetIdV2` and `testCanConvertBaseAssetIdV2ToProviderAsset`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)