### PR TITLE
Sync Solana asset into iOS resources (moonpay & onramper)

### DIFF
--- a/ios/Resources/buyassets/moonpay.json
+++ b/ios/Resources/buyassets/moonpay.json
@@ -351,6 +351,14 @@
             "ios_asset_protocol": "CCD",
             "android_blockchain": "CCD_BLOCKCHAIN",
             "android_asset_protocol": "CCD_PROTOCOL"
+        },
+        {
+            "currency_code": "SOL",
+            "asset_id": "SOL",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SOL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SOL_PROTOCOL"
         }
     ]
 }

--- a/ios/Resources/buyassets/onramper.json
+++ b/ios/Resources/buyassets/onramper.json
@@ -327,6 +327,14 @@
             "ios_asset_protocol": "XLM_TOKEN",
             "android_blockchain": "XLM_BLOCKCHAIN",
             "android_asset_protocol": "XLM_TOKEN_PROTOCOL"
+        },
+        {
+            "compound_key": "sol",
+            "asset_id": "SOL",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SOL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SOL_PROTOCOL"
         }
     ]
 }


### PR DESCRIPTION
## Problem
PR #45 ("add solana buy asset") added the Solana entry to the **root** `buyassets/moonpay.json` and `buyassets/onramper.json`, but the iOS target bundles `ios/Resources/buyassets/` (see `Package.swift` → `.process("Resources/buyassets")`, loaded via `Bundle.module` in `ios/AssetConverterInteractor.swift`). The iOS copies were never updated.

As a result, on iOS `convertProviderAssetToAssetIdV2("SOL", ...)` returns `nil`, so Solana is dropped from Buy and Sell asset lists. Android (which reads the root files) shows SOL correctly. This is the root cause of wallet-ios MTDB-26242 (SOL pre-selected from market detail but absent from the Sell list).

## Fix
Mirror the existing root Solana entries into `ios/Resources/buyassets/moonpay.json` and `ios/Resources/buyassets/onramper.json`, identical to the root files (moonpay keys by `currency_code: "SOL"`, onramper by `compound_key: "sol"`).

No code changes; JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)