### PR TITLE
feature: sol token

### DIFF
--- a/buyassets/moonpay.json
+++ b/buyassets/moonpay.json
@@ -359,6 +359,86 @@
             "ios_asset_protocol": "SOL",
             "android_blockchain": "SOL_BLOCKCHAIN",
             "android_asset_protocol": "SOL_PROTOCOL"
+        },
+        {
+            "currency_code": "BONK_SOL",
+            "asset_id": "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "currency_code": "CASH_SOL",
+            "asset_id": "CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "currency_code": "JUP_SOL",
+            "asset_id": "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "currency_code": "PENGU_SOL",
+            "asset_id": "2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "currency_code": "PYUSD_SOL",
+            "asset_id": "2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "currency_code": "TRUMP_SOL",
+            "asset_id": "6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "currency_code": "USDC_SOL",
+            "asset_id": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "currency_code": "USDT_SOL",
+            "asset_id": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "currency_code": "VINE_SOL",
+            "asset_id": "6AJcP7wuLwmRYLBNbi825wgguaPsWzPBEHcHndpRpump",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "currency_code": "XO_SOL",
+            "asset_id": "xoUSDq85Rjsb6SbUwJyreFgeWQvxdkT7R3c3g7s6p5Y",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
         }
     ]
 }

--- a/buyassets/onramper.json
+++ b/buyassets/onramper.json
@@ -343,6 +343,206 @@
             "ios_asset_protocol": "SOL",
             "android_blockchain": "SOL_BLOCKCHAIN",
             "android_asset_protocol": "SOL_PROTOCOL"
+        },
+        {
+            "compound_key": "srm_solana",
+            "asset_id": "SRM",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "usdc_solana",
+            "asset_id": "USDC",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "usdt_solana",
+            "asset_id": "USDT",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "fida_solana",
+            "asset_id": "FIDA",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "gari_solana",
+            "asset_id": "GARI",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "gmt_solana",
+            "asset_id": "GMT",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "gst_solana",
+            "asset_id": "GST",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "ray_solana",
+            "asset_id": "RAY",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "axset_solana",
+            "asset_id": "AXSet",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "sand_solana",
+            "asset_id": "SAND",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "taki_solana",
+            "asset_id": "TAKI",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "quick_solana",
+            "asset_id": "QUICK",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "isc_solana",
+            "asset_id": "ISC",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "c98_solana",
+            "asset_id": "C98",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "grt_solana",
+            "asset_id": "GRT",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "btc_solana",
+            "asset_id": "BTC",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "avax_solana",
+            "asset_id": "AVAX",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "eth_solana",
+            "asset_id": "ETH",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "doge_solana",
+            "asset_id": "DOGE",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "bonk_solana",
+            "asset_id": "BONK",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "pyusd_solana",
+            "asset_id": "PYUSD",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "barsik_solana",
+            "asset_id": "BARSIK",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "trump_solana",
+            "asset_id": "TRUMP",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "melania_solana",
+            "asset_id": "MELANIA",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "usd1_solana",
+            "asset_id": "USD1",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
         }
     ]
 }

--- a/ios/Resources/buyassets/moonpay.json
+++ b/ios/Resources/buyassets/moonpay.json
@@ -359,6 +359,86 @@
             "ios_asset_protocol": "SOL",
             "android_blockchain": "SOL_BLOCKCHAIN",
             "android_asset_protocol": "SOL_PROTOCOL"
+        },
+        {
+            "currency_code": "BONK_SOL",
+            "asset_id": "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "currency_code": "CASH_SOL",
+            "asset_id": "CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "currency_code": "JUP_SOL",
+            "asset_id": "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "currency_code": "PENGU_SOL",
+            "asset_id": "2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "currency_code": "PYUSD_SOL",
+            "asset_id": "2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "currency_code": "TRUMP_SOL",
+            "asset_id": "6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "currency_code": "USDC_SOL",
+            "asset_id": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "currency_code": "USDT_SOL",
+            "asset_id": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "currency_code": "VINE_SOL",
+            "asset_id": "6AJcP7wuLwmRYLBNbi825wgguaPsWzPBEHcHndpRpump",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "currency_code": "XO_SOL",
+            "asset_id": "xoUSDq85Rjsb6SbUwJyreFgeWQvxdkT7R3c3g7s6p5Y",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
         }
     ]
 }

--- a/ios/Resources/buyassets/onramper.json
+++ b/ios/Resources/buyassets/onramper.json
@@ -335,6 +335,206 @@
             "ios_asset_protocol": "SOL",
             "android_blockchain": "SOL_BLOCKCHAIN",
             "android_asset_protocol": "SOL_PROTOCOL"
+        },
+        {
+            "compound_key": "srm_solana",
+            "asset_id": "SRM",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "usdc_solana",
+            "asset_id": "USDC",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "usdt_solana",
+            "asset_id": "USDT",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "fida_solana",
+            "asset_id": "FIDA",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "gari_solana",
+            "asset_id": "GARI",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "gmt_solana",
+            "asset_id": "GMT",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "gst_solana",
+            "asset_id": "GST",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "ray_solana",
+            "asset_id": "RAY",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "axset_solana",
+            "asset_id": "AXSet",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "sand_solana",
+            "asset_id": "SAND",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "taki_solana",
+            "asset_id": "TAKI",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "quick_solana",
+            "asset_id": "QUICK",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "isc_solana",
+            "asset_id": "ISC",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "c98_solana",
+            "asset_id": "C98",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "grt_solana",
+            "asset_id": "GRT",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "btc_solana",
+            "asset_id": "BTC",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "avax_solana",
+            "asset_id": "AVAX",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "eth_solana",
+            "asset_id": "ETH",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "doge_solana",
+            "asset_id": "DOGE",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "bonk_solana",
+            "asset_id": "BONK",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "pyusd_solana",
+            "asset_id": "PYUSD",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "barsik_solana",
+            "asset_id": "BARSIK",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "trump_solana",
+            "asset_id": "TRUMP",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "melania_solana",
+            "asset_id": "MELANIA",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
+        },
+        {
+            "compound_key": "usd1_solana",
+            "asset_id": "USD1",
+            "ios_blockchain": "SOL",
+            "ios_asset_protocol": "SPL",
+            "android_blockchain": "SOL_BLOCKCHAIN",
+            "android_asset_protocol": "SPL_PROTOCOL"
         }
     ]
 }


### PR DESCRIPTION
This pull request expands the list of supported Solana-based tokens for both the Moonpay and Onramper fiat on-ramp providers, updating their configuration files for both Android and iOS platforms. The changes ensure that a broader set of SPL tokens can be purchased or on-ramped, improving compatibility and user choice.

**Moonpay asset additions:**
- Added support for several SPL tokens on Solana, including BONK, CASH, JUP, PENGU, PYUSD, TRUMP, USDC, USDT, VINE, and XO, with their corresponding asset IDs and protocol settings for both iOS and Android. 

**Onramper asset additions:**
- Added support for a wide range of SPL tokens on Solana, such as SRM, USDC, USDT, FIDA, GARI, GMT, GST, RAY, AXSet, SAND, TAKI, QUICK, ISC, C98, GRT, BTC, AVAX, ETH, DOGE, BONK, PYUSD, BARSIK, TRUMP, MELANIA, and USD1, each with appropriate compound keys, asset IDs, and protocol settings for both iOS and Android.